### PR TITLE
*urls* is now *routes* in CF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cf push
 
 Watch the output of the command for the URL of the Cloud Foundry app. Look for a line towards the end similar to the following:
 ```
-urls: bupa-mock-odata-<random-route>.cfapps.eu10.hana.ondemand.com
+routes: bupa-mock-odata-<random-route>.cfapps.eu10.hana.ondemand.com
 ```
 Access the mock OData service at that URL, by appending the path `/sap/opu/odata/sap/API_BUSINESS_PARTNER`.
 


### PR DESCRIPTION
JSON entity that points at service link was renamed to routes.

name:                odata-mock-server
requested state:     started
isolation segment:   trial
routes:              odata-mock-server-talkative-springhare-sr.cfapps.eu10.hana.ondemand.com
last uploaded:       Tue 14 Jan 11:19:17 CET 2020