### PR TITLE
Updated node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "uuid": "^3.3.3"
   },
   "engines": {
-    "node": "^8.9.4"
+    "node": "^12.16.1"
   },
   "devDependencies": {
     "@sap/cloud-sdk-generator": "^1.13.1",


### PR DESCRIPTION
Node version was outdated, the mock server couldn't be pushed to Cloud Foundry:
```
          engines.node (package.json): ^8.9.4
          engines.npm (package.json): unspecified (use default)
          **ERROR** Unable to install node: no match found for ^8.9.4 in [10.18.1 10.19.0 12.16.0 12.16.1 13.10.1 13.11.0]
   Failed to compile droplet: Failed to run all supply scripts: exit status 14
```
It can't be the latest node version because there is a warning:
```
          engines.node (package.json): ^13.11.0
          engines.npm (package.json): unspecified (use default)
   -----> Installing node 13.11.0
          Copy [/tmp/buildpacks/04e75c60fde5ec68e4561b0678ad2b21/dependencies/e0b63b6be6ee377e1027bf380f376926/node-13.11.0-linux-x64-cflinuxfs3-855d9f7a.tgz]
          **WARNING** node 13.x.x will no longer be available in new buildpacks released after 2020-06-01.
          See: https://github.com/nodejs/Release
```
This version works fine and the mock server has been tested:
```
          engines.node (package.json): ^12.16.1
          engines.npm (package.json): unspecified (use default)
   -----> Installing node 12.16.1
          Copy [/tmp/buildpacks/04e75c60fde5ec68e4561b0678ad2b21/dependencies/8eafd026d2296d9717517f96b62e7e0d/node-12.16.1-linux-x64-cflinuxfs3-7bb532cc.tgz]
```